### PR TITLE
Remove unnecessary import statement

### DIFF
--- a/templates/header.tmpl
+++ b/templates/header.tmpl
@@ -6,7 +6,5 @@ package {{.Package}}
 import (
 {{range .Imports}}{{.Name}} {{.Path}}
 {{end}}
-
-"github.com/google/go-cmp/cmp"
 )
 {{end}}


### PR DESCRIPTION
I believe manually importing `go-cmp` is not necessary, because `gotests` automatically handle imports.